### PR TITLE
Version 1.0.1.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Custom-Advancement-Messages
+# Custom Advancement Messages
 CAM allows you to customize the message for every advancement in the game. 
 That includes any advancement added by another plugin or data pack! 
 It supports sending JSON messages, HEX color codes, and also has full support for PlaceholderAPI and Vault prefixes & suffixes!

--- a/src/main/java/net/insprill/cam/CAM.java
+++ b/src/main/java/net/insprill/cam/CAM.java
@@ -128,6 +128,8 @@ public class CAM extends JavaPlugin {
         while (advancementIterator.hasNext()) {
             Advancement advancement = advancementIterator.next();
             String key = CF.formatKey(advancement);
+            if (key.contains("root") || key.contains("recipes"))
+                continue; // Skip if the advancements key contains 'root' or 'recipes'.
             if (!advancementsFile.getConfig().contains(key))
                 advancementsFile.set(key, "default");
         }

--- a/src/main/java/net/insprill/cam/listeners/AdvancementEvent.java
+++ b/src/main/java/net/insprill/cam/listeners/AdvancementEvent.java
@@ -28,7 +28,8 @@ public class AdvancementEvent implements Listener {
     @EventHandler
     public void onAdvancement(PlayerAdvancementDoneEvent e) {
         plugin.advancementProcessor.execute(() -> {
-            if (plugin.configFile.getStringList("Disabled-Advancements").contains(e.getAdvancement().getKey().toString()))
+            String advKey = e.getAdvancement().getKey().toString();
+            if (plugin.configFile.getStringList("Disabled-Advancements").contains(advKey))
                 return; // Return if the advancement is disabled.
             Player player = e.getPlayer(); // Looks prettier then e.getPlayer() a bunch of times.
             List<String> criteria = new ArrayList<>(e.getAdvancement().getCriteria()); // List of all criteria for advancement.
@@ -46,7 +47,6 @@ public class AdvancementEvent implements Listener {
                     plugin.dataFile = new YamlManager("data.yml");
                 storage:
                 {
-                    String advKey = e.getAdvancement().getKey().toString();
                     if (plugin.configFile.getBoolean("Store-Completed-Advancements.Only-Custom", true)
                             && advKey.startsWith("minecraft:")) // If SCA is enabled and only custom is true, break out of this.
                         break storage;
@@ -61,10 +61,31 @@ public class AdvancementEvent implements Listener {
 
             String message = plugin.advancementsFile.getString(CF.formatKey(e.getAdvancement())); // Message string we modify.
             if (message.equals("none")) return; // Return if the message is set to 'none'.
-            if (message.equals("default"))
-                message = plugin.advancementsFile.getString("default"); // If it's default, use the default message.
+            if (message.equals("default")) {
+                switch (getDefaultCategory(advKey)) { // Switch advancement type.
+                    case "nether":
+                        message = plugin.advancementsFile.getString("nether", "default");
+                        break;
+                    case "story":
+                        message = plugin.advancementsFile.getString("story", "default");
+                        break;
+                    case "adventure":
+                        message = plugin.advancementsFile.getString("adventure", "default");
+                        break;
+                    case "end":
+                        message = plugin.advancementsFile.getString("end", "default");
+                        break;
+                    case "husbandry":
+                        message = plugin.advancementsFile.getString("husbandry", "default");
+                        break;
+                    default:
+                        message = plugin.advancementsFile.getString("default", "default");
+                }
+                if (message.equals("default"))
+                    message = plugin.advancementsFile.getString("default", "&2[playerName] &ahas gotten the advancement &2[adv]&a!"); // If it's still default, use the default message.
+            }
 
-            String advName = e.getAdvancement().getKey().getKey(); // Advancement name from key.
+            String advName = advKey; // Advancement name from key.
             if (advName.contains("root") || advName.contains("recipes"))
                 return; // Return if the advancements key contains 'root' or 'recipes'.
             advName = advName.substring(advName.lastIndexOf('/') + 1); // Get the lowest key. That's the advancements name

--- a/src/main/java/net/insprill/cam/listeners/AdvancementEvent.java
+++ b/src/main/java/net/insprill/cam/listeners/AdvancementEvent.java
@@ -28,6 +28,8 @@ public class AdvancementEvent implements Listener {
     @EventHandler
     public void onAdvancement(PlayerAdvancementDoneEvent e) {
         plugin.advancementProcessor.execute(() -> {
+            if (plugin.configFile.getStringList("Disabled-Advancements").contains(e.getAdvancement().getKey().toString()))
+                return; // Return if the advancement is disabled.
             Player player = e.getPlayer(); // Looks prettier then e.getPlayer() a bunch of times.
             List<String> criteria = new ArrayList<>(e.getAdvancement().getCriteria()); // List of all criteria for advancement.
             if (criteria.isEmpty()) return; // If the advancement has no criteria, return;
@@ -65,9 +67,7 @@ public class AdvancementEvent implements Listener {
             String advName = e.getAdvancement().getKey().getKey(); // Advancement name from key.
             if (advName.contains("root") || advName.contains("recipes"))
                 return; // Return if the advancements key contains 'root' or 'recipes'.
-            advName = advName.substring(advName.lastIndexOf('/') + 1); // Get the lowest key. That's the advancements name.
-            if (plugin.configFile.getStringList("Disabled-Advancements").contains(advName))
-                return; // Return if the advancement is disabled.
+            advName = advName.substring(advName.lastIndexOf('/') + 1); // Get the lowest key. That's the advancements name
             advName = StringUtils.replace(advName, "_", " "); // Replace the '_' in the name with a space.
             advName = WordUtils.capitalizeFully(advName); // Capitalize the first letter in each work and make all others lowercase.
             message = CF.setPlaceholders(player, message, advName); // Set placeholders.

--- a/src/main/java/net/insprill/cam/listeners/AdvancementEvent.java
+++ b/src/main/java/net/insprill/cam/listeners/AdvancementEvent.java
@@ -112,4 +112,12 @@ public class AdvancementEvent implements Listener {
         return nearbyPlayers; // Return the list of players.
     }
 
+    String getDefaultCategory(String key) {
+        key = CF.formatKey(key);
+        if (key.startsWith("minecraft.")) {
+            key = key.substring(key.indexOf('.') + 1, StringUtils.ordinalIndexOf(key, ".", 2));
+        }
+        return key.toLowerCase();
+    }
+
 }

--- a/src/main/resources/advancementMessages.yml
+++ b/src/main/resources/advancementMessages.yml
@@ -13,3 +13,8 @@
 # If you want a message to be centered in the chatbot, put '<center>' at the beginning of the message.
 # If you don't want a message, set it to 'none'.
 default: "&2[playerName] &ahas gotten the advancement &2[adv]&a!"
+nether: default
+story: default
+adventure: default
+end: default
+husbandry: default

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -13,8 +13,9 @@ Radius:
 Store-Completed-Advancements:
   Enabled: false
   Only-Custom: true
-# Names of advancements to disable.
-# Names are the keys that holds the message value in the advancementMessages.yml.
+# List of advancements to disable.
+# You need to enter the full key in here for it to be disabled.
+# You can find full keys in the vanilla '/advancement' command.
 # Note: Disabling an advancement just means the messages doesn't get sent.
 Disabled-Advancements:
   - YourDisabledAdvancementHere

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: CAM
 main: net.insprill.cam.CAM
-version: 1.0.0.0
+version: 1.0.1.0
 softdepend:
   - Vault
   - PlaceholderAPI


### PR DESCRIPTION
Added:
    - Options to change message for each Minecraft category. (reference to update advancementMessages.yml).


Changed:
    - Disabled advancements now require the full key, not just the name.
    - Plugin name is shortened to 'CAM' (this almost means the data folder is 'CAM').
    - Don't add all 'root' & 'recipe' advancements to advancementsMessages file. (makes the file much much smaller as they were disabled internally anyways).